### PR TITLE
Make locking changes backwards compatible

### DIFF
--- a/zk/constants.go
+++ b/zk/constants.go
@@ -239,3 +239,10 @@ var (
 		ModeStandalone: "standalone",
 	}
 )
+
+// NoData is a shortcut for passing empty data to various Conn methods.
+var NoData = []byte{0}
+
+// WorldACLPermAll is a shortcut for passing acl permissions to various
+// Conn methods.
+var WorldACLPermAll = WorldACL(PermAll)

--- a/zk/lock.go
+++ b/zk/lock.go
@@ -39,10 +39,18 @@ func parseSeq(path string) (int, error) {
 	return strconv.Atoi(parts[len(parts)-1])
 }
 
-// Lock attempts to acquire the lock. It will wait to return until the lock
+// Lock attempts to acquire a lock. It will wait to return until the lock
 // is acquired or an error occurs. If this instance already has the lock
 // then ErrDeadlock is returned.
-func (l *Lock) Lock(data []byte) (string, error) {
+func (l *Lock) Lock() error {
+	_, err := l.LockWithData([]byte{})
+	return err
+}
+
+// LockWithData performs a lock in the same manner as the Lock method, but
+// in addition allows you to pass in data to be set on the locked node, and
+// will return the path to the node that acquired the lock.
+func (l *Lock) LockWithData(data []byte) (string, error) {
 	if l.lockPath != "" {
 		return "", ErrDeadlock
 	}


### PR DESCRIPTION
The previous locking changes broke backwards compatibility. 

This introduces a new method:

``` go
func (l *Lock) LockWithData(data []byte) (string, error) ...
```

And restores the original Lock method:

``` go
func (l *Lock) Lock() error ...
```

See also discussion in kenbreeman/vault/pull/1
